### PR TITLE
Remove fastchat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,8 @@ conda-update:
 .PHONY: streamlit-qa
 streamlit-qa:
 	streamlit run llm/qa/streamlit/app.py
+
+
+.PHONY: chat-qa
+chat-qa:
+	python llm/qa/cli/main.py chat --rephrase

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,6 @@ dependencies:
       - sentencepiece
       - sentence_transformers
       - langchain
-      - fschat
       - bitsandbytes
       - numpy<1.25,>=1.24
       - accelerate

--- a/llm/qa/cli/chat.py
+++ b/llm/qa/cli/chat.py
@@ -14,7 +14,7 @@ from llm.utils.dataset import load_data
 @click.option("--input-type", help="Input file type. Defaults to file extension.", default=None, envvar="QA_INPUT_TYPE")
 @click.option("--index-path", help="Path to a pre-built FAISS index over the dataset", default=None, envvar="QA_INDEX_PATH")
 @click.option("--context-model", help="Model name or path for context embedding", default=DEFAULT_MODEL, envvar="QA_CONTEXT_MODEL")
-@click.option("--rephrase", help="Rephrase the question with context from previous messages")
+@click.option("--rephrase", is_flag=True, help="Rephrase the question with context from previous messages")
 def chat_cli(input_path: str, input_type: Optional[str], index_path: Optional[str], context_model: str, rephrase: bool):
     dataset = load_data(input_path, input_type)
     if index_path is None:
@@ -35,6 +35,8 @@ def chat_cli(input_path: str, input_type: Optional[str], index_path: Optional[st
         qa_session.search_context(question)
 
         prev_output = ""
+        qa_session.append_answer("")
+        print(qa_session.get_history(range_start=-1), end="", flush=True)
         for output_text in qa_session.stream_answer(question):
             new_output = output_text[len(prev_output):]
             prev_output = output_text

--- a/llm/qa/cli/chat.py
+++ b/llm/qa/cli/chat.py
@@ -35,9 +35,7 @@ def chat_cli(input_path: str, input_type: Optional[str], index_path: Optional[st
         qa_session.search_context(question)
 
         prev_output = ""
-        qa_session.append_answer("")
-        print(qa_session.get_history(range_start=-1), end="", flush=True)
-        for output_text in qa_session.stream_answer(question):
+        for output_text in qa_session.stream_answer(question, with_prefix=True):
             new_output = output_text[len(prev_output):]
             prev_output = output_text
             print(new_output, end="", flush=True)

--- a/llm/qa/inference.py
+++ b/llm/qa/inference.py
@@ -49,11 +49,14 @@ class TransformersEngine(InferenceEngine):
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
         stop_str: Union[str, List[str]] = "",
-        **logits_processor_kwargs: Any,
+        logits_config: Optional[LogitsProcessorConfig] = None,
     ) -> Iterable[str]:
         logits_processor: Optional[LogitsProcessorList] = None
-        logits_config = LogitsProcessorConfig(**logits_processor_kwargs)
-        logits_processor = logits_config.load()
+        if logits_config:
+            logits_processor = logits_config.load()
+            do_sampling = logits_config.do_sampling
+        else:
+            do_sampling = True
 
         if not stop_token_ids:
             if self.tokenizer.eos_token_id is not None:
@@ -65,50 +68,38 @@ class TransformersEngine(InferenceEngine):
         input_ids = self.tokenizer(prompt).input_ids
         output_ids = list(input_ids)
 
-        max_src_len = self.max_length - max_new_tokens - 8
+        if self.model.config.is_encoder_decoder:
+            max_src_len = self.max_length
+        else:
+            max_src_len = self.max_length - max_new_tokens - 8
         input_ids = input_ids[-max_src_len:]
         input_echo_len = len(input_ids)
 
-        past_key_values = out = None
         token: Optional[int] = None
         stopped = False
-        for i in range(max_new_tokens):
-            if not token:
-                # First pass, must calculate attention for entire input
-                input_tensor = torch.as_tensor([input_ids], device=self.model.device)
-            else:
-                # Calculate attention on the latest token only, re-use attention
-                # for the previous tokens via past_key_values
-                input_tensor = torch.as_tensor([[token]], device=self.model.device)
 
-            # Run inference
-            out = self.model(
-                input_ids=input_tensor,
-                use_cache=True,
-                past_key_values=past_key_values,
-            )
-            logits = out.logits
-            past_key_values = out.past_key_values
+        # First step calculates attention of full input
+        logits, past_key_values, encoder_output = self.prefill(input_ids)
+        for i in range(max_new_tokens):
+            if token:
+                # After the first step, only calculate attention of the new token.
+                # Previous tokens are represented by past_key_values
+                logits, past_key_values = self.decoder(
+                    token, past_key_values, encoder_output=encoder_output
+                )
 
             # Process output
-            output_tensor = torch.as_tensor([output_ids], device=logits.device)
-            last_token_logits = logits_processor(output_tensor, logits[:, -1, :])[0]
-
-            if logits_config.do_sampling:
-                # Sample token from the distribution
-                probs = torch.softmax(last_token_logits, dim=-1)
-                token = int(torch.multinomial(probs, num_samples=1))
-            else:
-                # Take most probable token
-                token = int(torch.argmax(last_token_logits))
+            token = self.process_logits(
+                logits, output_ids, logits_processor=logits_processor, do_sampling=do_sampling
+            )
             output_ids.append(token)
 
-            # Check stopping conditions
+            # Check token stopping conditions
             if token in stop_token_ids or i == max_new_tokens - 1:
                 stopped = True
 
-            if i % stream_interval == 0 or stopped:
-                # Decode and yield current output
+            if (stream_interval > 0 and i % stream_interval == 0) or stopped:
+                # Decode tokens and yield current output
                 if echo_prompt:
                     tmp_output_ids = output_ids
                     rfind_start = len_prompt
@@ -123,22 +114,123 @@ class TransformersEngine(InferenceEngine):
                     clean_up_tokenization_spaces=True,
                 )
 
+                # Check string stopping conditions
                 stop_pos, partially_stopped = check_stop_str(output, stop_str, rfind_start)
                 if stop_pos != -1:
                     output = output[:stop_pos]
                     stopped = True
 
                 # prevent yielding partially completed stop sequences
-                if not partially_stopped:
+                if not partially_stopped or stopped:
                     yield output
 
             if stopped:
                 break
 
         # clean
-        del past_key_values, out
+        del past_key_values, logits, encoder_output
         gc.collect()
         torch.cuda.empty_cache()
+
+    def prefill(
+            self, input_ids: List[int]
+        ) -> Tuple[
+            torch.FloatTensor, Tuple[Tuple[torch.FloatTensor]], Optional[Tuple[torch.FloatTensor]]
+        ]:
+        """
+        Initial encoding of input, followed by a single decode step.
+
+        Return: logits, past_key_values, encoder_ouput
+        """
+        input_tensor = torch.as_tensor([input_ids], device=self.model.device)
+        encoder_output: Optional[torch.Tensor] = None
+        if self.model.config.is_encoder_decoder:
+            # Encoder-Decoder models
+            encoder_output = self.model.encoder(input_ids=input_tensor)[0]
+            start_ids = torch.as_tensor(
+                [[self.model.generation_config.decoder_start_token_id]],
+                dtype=torch.int64,
+                device=self.model.device,
+            )
+            out = self.model.decoder(
+                input_ids=start_ids,
+                encoder_hidden_states=encoder_output,
+                use_cache=True,
+            )
+            logits = self.model.lm_head(out[0])
+        else:
+            # Decoder-only models
+            out = self.model(input_tensor, use_cache=True)
+            logits = out.logits
+        return logits, out.past_key_values, encoder_output
+
+    def decoder(
+        self,
+        last_token: int,
+        past_key_values: Tuple[Tuple[torch.FloatTensor]],
+        encoder_output: Optional[Tuple[torch.FloatTensor]] = None,
+    ) -> Tuple[torch.FloatTensor, Tuple[Tuple[torch.FloatTensor]]]:
+        """
+        Run a single decode step on the model. Only calculate attention on the most recent token generated,
+        previous token's attention is preserved through past_key_values.
+
+        Return: logits, past_key_values
+        """
+        input_tensor = torch.as_tensor([[last_token]], device=self.model.device)
+        if self.model.config.is_encoder_decoder:
+            # Encoder-Decoder models
+            out = self.model.decoder(
+                input_ids=input_tensor,
+                encoder_hidden_states=encoder_output,
+                use_cache=True,
+                past_key_values=past_key_values,
+            )
+            logits = self.model.lm_head(out[0])
+        else:
+            # Decoder-only models
+            out = self.model(
+                input_ids=input_tensor,
+                use_cache=True,
+                past_key_values=past_key_values,
+            )
+            logits = out.logits
+        return logits, out.past_key_values
+
+    def process_logits(
+        self,
+        logits: torch.Tensor,
+        output_ids: List[int],
+        logits_processor: Optional[LogitsProcessorList] = None,
+        do_sampling: bool = True,
+    ) -> int:
+        """
+        Process logits and determine the next token in the sequence.
+
+        Return: token
+        """
+        output_tensor = torch.as_tensor([output_ids], device=logits.device)
+        if logits_processor:
+            last_token_logits = logits_processor(output_tensor, logits[:, -1, :])[0]
+        else:
+            last_token_logits = logits[0, -1, :]
+
+        if self.model.device.type == "mps":
+            # Switch to CPU by avoiding some bugs in mps backend.
+            last_token_logits = last_token_logits.float().to("cpu")
+
+        if do_sampling:
+            # Sample token from the distribution
+            probs = torch.softmax(last_token_logits, dim=-1)
+            token = int(torch.multinomial(probs, num_samples=1))
+        else:
+            # Take most probable token
+            token = int(torch.argmax(last_token_logits))
+        return token
+
+    def get_answer(self, prompt: str, **kwargs) -> str:
+        # Avoid decoding tokens until the final step
+        kwargs.setdefault("stream_interval", -1)
+        return super().get_answer(prompt, **kwargs)
 
 
 class QueuedEngine(InferenceEngine):
@@ -202,7 +294,7 @@ class LogitsProcessorConfig:
     top_k: int = -1
     repetition_penalty: float = 1.0
     do_sampling: Optional[bool] = None
-    processors: List[LogitsProcessor, LogitsWarper] = field(default_factory=list)
+    additional: List[Union[LogitsProcessor, LogitsWarper]] = field(default_factory=list)
 
     def __post_init__(self):
         if self.do_sampling is None:
@@ -221,8 +313,8 @@ class LogitsProcessorConfig:
             processors.append(TopKLogitsWarper(self.top_k))
         if self.repetition_penalty != 1.0:
             processors.append(RepetitionPenaltyLogitsProcessor(self.repetition_penalty))
-        if self.processors:
-            processors.extend(self.processors)
+        if self.additional:
+            processors.extend(self.additional)
         return LogitsProcessorList(processors)
 
 

--- a/llm/qa/inference.py
+++ b/llm/qa/inference.py
@@ -211,7 +211,7 @@ class LogitsProcessorArgs:
     top_p: float = 1.0
     top_k: int = -1
     repetition_penalty: float = 1.0
-    additional: List[LogitsProcessor, LogitsWarper] = field(default_factory=list)
+    processors: List[LogitsProcessor, LogitsWarper] = field(default_factory=list)
 
     def load(self) -> LogitsProcessorList:
         processors = []
@@ -223,8 +223,8 @@ class LogitsProcessorArgs:
             processors.append(TopKLogitsWarper(self.top_k))
         if self.repetition_penalty != 1.0:
             processors.append(RepetitionPenaltyLogitsProcessor(self.repetition_penalty))
-        if self.additional:
-            processors.extend(self.additional)
+        if self.processors:
+            processors.extend(self.processors)
         return LogitsProcessorList(processors)
 
 

--- a/llm/qa/model_configs.py
+++ b/llm/qa/model_configs.py
@@ -22,7 +22,6 @@ default_conversation_kwargs = {
     "roles": ("Question", "Answer"),
     "sep_style": SeparatorStyle.ADD_COLON_SINGLE,
     "sep": "\n",
-    "stop_str": "Question:",
 }
 
 
@@ -113,7 +112,6 @@ REDPAJAMA_INSTRUCT = ChatModelConfig(
     default_prompt=prompts.FEW_SHOT,
     conversation_kwargs={
         "roles": ("<human>", "<bot>"),
-        "stop_str": "<human>:",
     },
 )
 
@@ -121,7 +119,6 @@ REDPAJAMA_CHAT = ChatModelConfig(
     "togethercomputer/RedPajama-INCITE-7B-Chat",
     conversation_kwargs={
         "roles": ("<human>", "<bot>"),
-        "stop_str": "<human>:",
     }
 )
 

--- a/llm/qa/model_configs.py
+++ b/llm/qa/model_configs.py
@@ -17,6 +17,7 @@ default_model_kwargs = {
 }
 default_tokenizer_kwargs = {
     "use_fast": True,
+    # https://github.com/huggingface/transformers/pull/24565
     "legacy": False,
 }
 default_conversation_kwargs = {

--- a/llm/qa/session.py
+++ b/llm/qa/session.py
@@ -7,7 +7,7 @@ from langchain.schema import Document
 from langchain.vectorstores.base import VectorStore
 from langchain.schema.messages import AIMessage, BaseMessage, HumanMessage
 
-from llm.qa.inference import TransformersEngine, InferenceEngine
+from llm.qa.inference import LogitsProcessorConfig, TransformersEngine, InferenceEngine
 from llm.qa.model_configs import ChatModelConfig
 from llm.qa.prompts import STANDALONE_QUESTION, ZERO_SHOT, ContextPrompt
 
@@ -33,6 +33,7 @@ class QASession:
         self.debug = debug
         self.results: List[Document] = []
         self.contexts: List[str] = []
+        self.logits_config = LogitsProcessorConfig(temperature=0.7, top_p=0.9)
 
     @classmethod
     def from_model_config(
@@ -67,8 +68,7 @@ class QASession:
 
         gen_kwargs = {
             "stop_str": [f"{self.conv.human_prefix}:", f"{self.prompt.default_context_label}:"],
-            "temperature": 0.9,
-            "top_p": 0.9,
+            "logits_config": self.logits_config,
             **kwargs,
         }
         prefix = ""
@@ -107,8 +107,7 @@ class QASession:
         )
         params = {
             "stop_str": f"{self.conv.human_prefix}:",
-            "temperature": 0.7,
-            "top_p": 0.9,
+            "logits_config": self.logits_config,
             **kwargs,
         }
         standalone = self.engine.get_answer(input_text, **params).strip()

--- a/llm/qa/streamlit/app.py
+++ b/llm/qa/streamlit/app.py
@@ -126,11 +126,9 @@ if qa_session.results:
 if not clear_convo:
     if query_submitted:
         # Stream response from LLM, updating chat window at each step
-        # Append empty answer to be filled in later
-        qa_session.append_answer("")
-        message_string = qa_session.get_history(separator=MARKDOWN_LINEBREAK)
-        for text in qa_session.stream_answer(question):
-            message = message_string + text
+        history = qa_session.get_history(separator=MARKDOWN_LINEBREAK) + MARKDOWN_LINEBREAK
+        for text in qa_session.stream_answer(question, with_prefix=True):
+            message = history + text
             output.write(message)
     else:
         # Write existing message history

--- a/llm/qa/streamlit/app.py
+++ b/llm/qa/streamlit/app.py
@@ -126,7 +126,7 @@ if qa_session.results:
 if not clear_convo:
     if query_submitted:
         # Stream response from LLM, updating chat window at each step
-        history = qa_session.get_history(separator=MARKDOWN_LINEBREAK) + MARKDOWN_LINEBREAK
+        history = qa_session.get_history(separator=MARKDOWN_LINEBREAK, range_start=0) + MARKDOWN_LINEBREAK
         for text in qa_session.stream_answer(question, with_prefix=True):
             message = history + text
             output.write(message)

--- a/llm/qa/streamlit/app.py
+++ b/llm/qa/streamlit/app.py
@@ -6,7 +6,7 @@ from langchain.vectorstores.base import VectorStore
 
 from llm.qa import model_configs
 from llm.qa.embedding import DEFAULT_MODEL, QAEmbeddings
-from llm.qa.inference import FastchatEngine, InferenceEngine, QueuedEngine
+from llm.qa.inference import TransformersEngine, InferenceEngine, QueuedEngine
 from llm.qa.session import QASession
 from llm.qa.parser import DataFields
 from llm.qa.vector_store import DatasetVectorStore
@@ -26,7 +26,7 @@ st.set_page_config(page_title="QA Chat", page_icon=":robot_face:", layout="wide"
 def get_inference_engine() -> InferenceEngine:
     # Load chat model and inference engine. Shared by all sessions
     model, tokenizer = model_config.load()
-    engine = FastchatEngine(model, tokenizer, max_length=model_config.max_length)
+    engine = TransformersEngine(model, tokenizer, max_length=model_config.max_length)
     # Wrap with QueuedEngine so each streamlit session has dedicated access during inference
     return QueuedEngine(engine)
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Fastchat is currently pinning an older version of transformers, but we want to be able to use latest (which includes support for Llama2, 4bit quantization, etc.). Not getting that much value out of the fastchat dependency, so replacing it with other components. 

- Created our own generate_stream function based on fastchat and other sources
- Replacing Conversation with langchain ConversationBufferWindowMemory (since we already depend on langchain for other things)
  - Not a perfect fit for what we're doing with it, but works well enough for now.
