### PR TITLE
Run inference engines in background processes

### DIFF
--- a/llm/qa/model_configs.py
+++ b/llm/qa/model_configs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Dict, Optional, Tuple, Type, Union
 import torch
 from langchain.memory.buffer_window import ConversationBufferWindowMemory
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizerBase
@@ -56,10 +56,13 @@ class ModelConfig:
             self.model_kwargs = merge_dict(self.model_kwargs, default_model_kwargs)
             self.tokenizer_kwargs = merge_dict(self.tokenizer_kwargs, default_tokenizer_kwargs)
 
-    def load(self) -> Tuple[PreTrainedModel, PreTrainedTokenizerBase]:
+    def load(self, device: Optional[Union[int, str]] = None) -> Tuple[PreTrainedModel, PreTrainedTokenizerBase]:
         model_cls = self.model_cls or AutoModelForCausalLM
         tokenizer_cls = self.tokenizer_cls or AutoTokenizer
-        model = model_cls.from_pretrained(self.name, **self.model_kwargs)
+        model_kwargs = {**self.model_kwargs}
+        if device:
+            model_kwargs["device_map"] = {"": device}
+        model = model_cls.from_pretrained(self.name, **model_kwargs)
         tokenizer = tokenizer_cls.from_pretrained(self.name, **self.tokenizer_kwargs)
         return model, tokenizer
 

--- a/llm/qa/model_configs.py
+++ b/llm/qa/model_configs.py
@@ -60,7 +60,7 @@ class ModelConfig:
         model_cls = self.model_cls or AutoModelForCausalLM
         tokenizer_cls = self.tokenizer_cls or AutoTokenizer
         model_kwargs = {**self.model_kwargs}
-        if device:
+        if device is not None:
             model_kwargs["device_map"] = {"": device}
         model = model_cls.from_pretrained(self.name, **model_kwargs)
         tokenizer = tokenizer_cls.from_pretrained(self.name, **self.tokenizer_kwargs)


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Running multiple transformer models in threads is incredibly inefficient due to the python GIL. The standard python implementation of transformers spends a lot of time in python code, and therefore must hold the GIL frequently during inference.

Replacing the threaded QueuedEngine with a MultiprocessEngine that runs models as background processes, and communicating via multiprocessing Pipe.