### PR TITLE
Bhperry/prompt management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ chat-cmdline:
 .PHONY: chat-streamlit
 chat-streamlit:
 	python llm/qa/cli/main.py chat streamlit
+
+
+.PHONY: format
+format:
+	black -l 100

--- a/llm/inference/multiproc.py
+++ b/llm/inference/multiproc.py
@@ -17,6 +17,7 @@ class MultiprocessEngine(InferenceEngine):
 
     Enables thread-safe non-blocking inference across multiple devices
     """
+
     def __init__(self, workers: List[WorkerPipe]):
         self.workers = workers
         self.closed = False
@@ -25,7 +26,13 @@ class MultiprocessEngine(InferenceEngine):
             self.queue.put(worker)
 
     @classmethod
-    def from_model_config(cls, model_config: ModelConfig, num_workers: Optional[int] = None, wait: bool = True, **kwargs) -> MultiprocessEngine:
+    def from_model_config(
+        cls,
+        model_config: ModelConfig,
+        num_workers: Optional[int] = None,
+        wait: bool = True,
+        **kwargs,
+    ) -> MultiprocessEngine:
         # Required for CUDA
         set_start_method("spawn")
 
@@ -54,8 +61,16 @@ class MultiprocessEngine(InferenceEngine):
         return cls(workers)
 
     @staticmethod
-    def _transformers_worker(pipe: WorkerPipe, model_config: ModelConfig, local_rank: int, signal_ready: bool = False, **kwargs):
-        engine = TransformersEngine.from_model_config(model_config, device_map={"": local_rank}, **kwargs)
+    def _transformers_worker(
+        pipe: WorkerPipe,
+        model_config: ModelConfig,
+        local_rank: int,
+        signal_ready: bool = False,
+        **kwargs,
+    ):
+        engine = TransformersEngine.from_model_config(
+            model_config, device_map={"": local_rank}, **kwargs
+        )
         if signal_ready:
             pipe.send_response(None)
         while True:
@@ -101,6 +116,7 @@ class StreamRequest:
     """
     Wraps an inference request to be processed by a worker
     """
+
     def __init__(self, prompt: str, **kwargs) -> None:
         self.prompt = prompt
         self.kwargs = kwargs
@@ -116,11 +132,11 @@ class StreamRequest:
         return cls(**data)
 
 
-
 class WorkerPipe:
     """
     Manages communication between an inference worker and the main process
     """
+
     def __init__(self):
         self.parent_conn, self.child_conn = Pipe()
 

--- a/llm/inference/transformer.py
+++ b/llm/inference/transformer.py
@@ -5,7 +5,15 @@ import gc
 from typing import Iterable, List, Optional, Tuple, Union
 
 import torch
-from transformers import PreTrainedModel, PreTrainedTokenizerBase, LogitsProcessorList, RepetitionPenaltyLogitsProcessor, TemperatureLogitsWarper, TopPLogitsWarper, TopKLogitsWarper
+from transformers import (
+    PreTrainedModel,
+    PreTrainedTokenizerBase,
+    LogitsProcessorList,
+    RepetitionPenaltyLogitsProcessor,
+    TemperatureLogitsWarper,
+    TopPLogitsWarper,
+    TopKLogitsWarper,
+)
 
 from llm.inference.base import InferenceEngine
 from llm.model_configs import ModelConfig
@@ -15,6 +23,7 @@ class TransformersEngine(InferenceEngine):
     """
     Generate a token stream from a prompt with the given transformer model
     """
+
     def __init__(
         self,
         model: PreTrainedModel,
@@ -125,10 +134,10 @@ class TransformersEngine(InferenceEngine):
         torch.cuda.empty_cache()
 
     def prefill(
-            self, input_ids: List[int]
-        ) -> Tuple[
-            torch.FloatTensor, Tuple[Tuple[torch.FloatTensor]], Optional[Tuple[torch.FloatTensor]]
-        ]:
+        self, input_ids: List[int]
+    ) -> Tuple[
+        torch.FloatTensor, Tuple[Tuple[torch.FloatTensor]], Optional[Tuple[torch.FloatTensor]]
+    ]:
         """
         First pass through the model. Attention is calculated for the entire input.
         In subsequent steps, attention is only calculated for new tokens.

--- a/llm/inference/vllm_client.py
+++ b/llm/inference/vllm_client.py
@@ -50,7 +50,13 @@ class VLLMClient(InferenceEngine):
     ) -> Iterable[str]:
         if not isinstance(stop, list):
             stop = [stop]
-        data = {"prompt": prompt, "stream": stream, "max_tokens": max_new_tokens, "stop": stop, **kwargs}
+        data = {
+            "prompt": prompt,
+            "stream": stream,
+            "max_tokens": max_new_tokens,
+            "stop": stop,
+            **kwargs,
+        }
         url = os.path.join(self.base_url, "generate")
 
         response = self.session.post(url, json=data, stream=stream)
@@ -71,5 +77,5 @@ class VLLMClient(InferenceEngine):
     def _trim_answer(self, prompt: str, answer: str, echo_prompt: bool = False) -> str:
         if not echo_prompt:
             if answer.startswith(prompt):
-                return answer[len(prompt):]
+                return answer[len(prompt) :]
         return answer

--- a/llm/model_configs.py
+++ b/llm/model_configs.py
@@ -14,7 +14,15 @@ from transformers import (
     __version__ as TRANSFORMERS_VERSION,
 )
 
-from llm.prompt import ChatMLFormat, DollyFormat, Llama2Format, PromptFormat, RedpajamaFormat, TogetherLlama2Format, VicunaFormat
+from llm.prompt import (
+    ChatMLFormat,
+    DollyFormat,
+    Llama2Format,
+    PromptFormat,
+    RedpajamaFormat,
+    TogetherLlama2Format,
+    VicunaFormat,
+)
 
 _registry: Dict[str, Type[ModelConfig]] = {}
 
@@ -44,6 +52,7 @@ class ModelConfig:
     PEFT models use their peft adapter name as model_id,
     and set the base model ID in peft_base_id.
     """
+
     model_id: str = ""
     max_length: int = 2048
     format: PromptFormat = field(default_factory=PromptFormat)
@@ -80,7 +89,9 @@ class ModelConfig:
         if model_id in _registry:
             cls = _registry[model_id]
         else:
-            logging.warn(f'ModelConfig "{model_id}" not found in registry. Using generic configuration.')
+            logging.warn(
+                f'ModelConfig "{model_id}" not found in registry. Using generic configuration.'
+            )
 
         return cls(model_id=model_id, **kwargs)
 
@@ -108,6 +119,7 @@ class ModelConfig:
         model = model_cls.from_pretrained(model_id, **model_kwargs)
         if self.peft_base_id:
             from peft import PeftModel
+
             model = PeftModel.from_pretrained(model, self.model_id, **self.peft_kwargs)
         return model
 
@@ -200,11 +212,13 @@ class RedpajamaChatConfig(ModelConfig):
 class MPTInstructConfig(ModelConfig):
     model_id: str = "mosaicml/mpt-7b-instruct"
     format: PromptFormat = field(default_factory=DollyFormat)
-    model_kwargs: Dict[str, Any] = field(default_factory=lambda: {
-        "init_device": "meta",
-        # MPT not yet full supported by Transformers
-        "trust_remote_code": True,
-    })
+    model_kwargs: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "init_device": "meta",
+            # MPT not yet full supported by Transformers
+            "trust_remote_code": True,
+        }
+    )
 
 
 MPTInstructConfig.register(
@@ -217,11 +231,13 @@ MPTInstructConfig.register(
 class MPTChatConfig(ModelConfig):
     model_id: str = "mosaicml/mpt-7b-chat"
     format: PromptFormat = field(default_factory=ChatMLFormat)
-    model_kwargs: Dict[str, Any] = field(default_factory=lambda: {
-        "init_device": "meta",
-        # MPT not yet full supported by Transformers
-        "trust_remote_code": True,
-    })
+    model_kwargs: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "init_device": "meta",
+            # MPT not yet full supported by Transformers
+            "trust_remote_code": True,
+        }
+    )
 
 
 MPTChatConfig.register(

--- a/llm/prompt.py
+++ b/llm/prompt.py
@@ -142,7 +142,7 @@ class DollyFormat(PromptFormat):
 class Message:
     input: str
     response: Optional[str] = None
-    contexts: List[str] = field(default_factory=list)
+    contexts: Optional[List[str]] = None
 
 
 @dataclass
@@ -350,7 +350,7 @@ class Conversation:
         # Remove contexts from old messages
         if self.context_retention > 0 and len(self.messages) > self.context_retention:
             for message in self.messages[existing_count-1:-self.context_retention]:
-                message.contexts = []
+                message.contexts = None
 
     def clear(self):
         self.messages = []

--- a/llm/qa/cli/chat.py
+++ b/llm/qa/cli/chat.py
@@ -19,11 +19,33 @@ def chat_cli():
 
 @chat_cli.command("cmdline", short_help="Conversational question answering from semantic search")
 @click.argument("dataset-path", required=True, envvar="QA_DATASET_PATH")
-@click.option("--dataset-type", help="Input file type. Defaults to file extension.", default=None, envvar="QA_INPUT_TYPE")
-@click.option("--index-path", help="Path to a pre-built FAISS index over the dataset", default=None, envvar="QA_INDEX_PATH")
-@click.option("--model-id", help="Chat model ID for prompt formatting.", default=VicunaConfig.model_id, envvar="QA_CHAT_MODEL")
-@click.option("--context-model", help="Model name or path for context embedding", default=DEFAULT_MODEL, envvar="QA_CONTEXT_MODEL")
-@click.option("--rephrase", is_flag=True, help="Rephrase the question with context from previous messages")
+@click.option(
+    "--dataset-type",
+    help="Input file type. Defaults to file extension.",
+    default=None,
+    envvar="QA_INPUT_TYPE",
+)
+@click.option(
+    "--index-path",
+    help="Path to a pre-built FAISS index over the dataset",
+    default=None,
+    envvar="QA_INDEX_PATH",
+)
+@click.option(
+    "--model-id",
+    help="Chat model ID for prompt formatting.",
+    default=VicunaConfig.model_id,
+    envvar="QA_CHAT_MODEL",
+)
+@click.option(
+    "--context-model",
+    help="Model name or path for context embedding",
+    default=DEFAULT_MODEL,
+    envvar="QA_CONTEXT_MODEL",
+)
+@click.option(
+    "--rephrase", is_flag=True, help="Rephrase the question with context from previous messages"
+)
 @click.option("--max-new-tokens", default=256, type=int, help="Max new generated tokens")
 @click.option("--temperature", default=0.7, type=float, help="Logit sampling temperature")
 @click.option("--top-p", default=1.0, type=float, help="Logit sampling Top P")
@@ -63,7 +85,7 @@ def cmdline_cli(
         for output_text in qa_session.stream_answer(
             input_text, max_new_tokens=max_new_tokens, temperature=temperature, top_p=top_p
         ):
-            new_output = output_text[len(prev_output):]
+            new_output = output_text[len(prev_output) :]
             prev_output = output_text
             print(new_output, end="", flush=True)
         print()
@@ -80,16 +102,30 @@ def streamlit_cli(ctx):
 
 
 @streamlit_cli.command("transformers", short_help="Local transformers engine")
-@click.option("--model-id", help="Chat model ID.", default=VicunaConfig.model_id, envvar="QA_CHAT_MODEL")
-@click.option("--num-workers", type=int, default=None, help="Number of chat models to run. Defaults to num GPUs")
-@click.option("--dataset", required=True, help="Path to dataset with contexts. Defaults to env QA_DATASET_PATH", envvar="QA_DATASET_PATH")
+@click.option(
+    "--model-id", help="Chat model ID.", default=VicunaConfig.model_id, envvar="QA_CHAT_MODEL"
+)
+@click.option(
+    "--num-workers",
+    type=int,
+    default=None,
+    help="Number of chat models to run. Defaults to num GPUs",
+)
+@click.option(
+    "--dataset",
+    required=True,
+    help="Path to dataset with contexts. Defaults to env QA_DATASET_PATH",
+    envvar="QA_DATASET_PATH",
+)
 @click.option(
     "--index",
     help="Path to a pre-built FAISS index over the dataset. Defaults to env QA_INDEX_PATH or <dataset-name>.faiss",
     default=None,
     envvar="QA_INDEX_PATH",
 )
-def transformers_backend(model_id: str, num_workers: Optional[int], dataset: str, index: Optional[str]) -> QASession:
+def transformers_backend(
+    model_id: str, num_workers: Optional[int], dataset: str, index: Optional[str]
+) -> QASession:
     os.environ["QA_DATASET_PATH"] = dataset
     if index:
         os.environ["QA_INDEX_PATH"] = index
@@ -101,8 +137,18 @@ def transformers_backend(model_id: str, num_workers: Optional[int], dataset: str
 
 @streamlit_cli.command("vllm-client", short_help="Remote vLLM engine")
 @click.argument("url")
-@click.option("--model-id", help="Chat model ID for prompt formatting.", default=VicunaConfig.model_id, envvar="QA_CHAT_MODEL")
-@click.option("--dataset", required=True, help="Path to dataset with contexts. Defaults to env QA_DATASET_PATH", envvar="QA_DATASET_PATH")
+@click.option(
+    "--model-id",
+    help="Chat model ID for prompt formatting.",
+    default=VicunaConfig.model_id,
+    envvar="QA_CHAT_MODEL",
+)
+@click.option(
+    "--dataset",
+    required=True,
+    help="Path to dataset with contexts. Defaults to env QA_DATASET_PATH",
+    envvar="QA_DATASET_PATH",
+)
 @click.option(
     "--index",
     help="Path to a pre-built FAISS index over the dataset. Defaults to env QA_INDEX_PATH or <dataset-name>.faiss",

--- a/llm/qa/cli/data.py
+++ b/llm/qa/cli/data.py
@@ -21,9 +21,22 @@ def data_cli():
 @click_coroutine
 @click.argument("url", required=True)
 @click.option("-o", "--output-path", required=True, help="Output path for the dataset")
-@click.option("domains", "-d", "--domain", multiple=True, help="One or more domains that can be scraped from the url. Any by default.", default=None)
-@click.option("--link-regex", help="Match URLs against regex before adding to scrape pipeline", default=None)
-@click.option("--text-css", help="Only extract text from elements matching the given CSS selector", default=None)
+@click.option(
+    "domains",
+    "-d",
+    "--domain",
+    multiple=True,
+    help="One or more domains that can be scraped from the url. Any by default.",
+    default=None,
+)
+@click.option(
+    "--link-regex", help="Match URLs against regex before adding to scrape pipeline", default=None
+)
+@click.option(
+    "--text-css",
+    help="Only extract text from elements matching the given CSS selector",
+    default=None,
+)
 @click.option("--max-depth", default=10, type=int, help="Maximum depth of URL links to follow")
 async def scrape(
     url: str,
@@ -47,12 +60,16 @@ async def scrape(
     save_data(dataset, output_path)
 
 
-@data_cli.command(short_help="Format text and ID fields of the dataset to known keys, generating a UUID for each row if needed")
+@data_cli.command(
+    short_help="Format text and ID fields of the dataset to known keys, generating a UUID for each row if needed"
+)
 @click.argument("input-path", required=True)
 @click.option("-o", "--output-path", required=True, help="Output path for the parsed dataset")
 @click.option("--input-type", help="Input file type. Defaults to file extension.")
 @click.option("--batch-size", help="Batch size for processing rows of the dataset", default=100)
-@click.option("--source-text-field", help="Text field of the source dataset", default=str(DataFields.TEXT))
+@click.option(
+    "--source-text-field", help="Text field of the source dataset", default=str(DataFields.TEXT)
+)
 @click.option("--source-id-field", help="ID field of the source dataset", default=None)
 def format(
     input_path: str,
@@ -74,14 +91,21 @@ def format(
     save_data(dataset, output_path)
 
 
-@data_cli.command(short_help="Split the dataset on its text field such that each chunk is of a given maximum size")
+@data_cli.command(
+    short_help="Split the dataset on its text field such that each chunk is of a given maximum size"
+)
 @click.argument("input-path", required=True)
 @click.option("-o", "--output-path", required=True, help="Output path for the parsed dataset")
 @click.option("--input-type", help="Input file type. Defaults to file extension.")
 @click.option("--batch-size", help="Batch size for processing rows of the dataset", default=100)
 @click.option("--chunk-size", help="Max chunk size of final text in number of tokens", default=256)
 @click.option("--chunk-overlap", help="Number of tokens to overlap between chunks", default=32)
-@click.option("--context-model", help="Model name or path for splitting contexts by token length", default=DEFAULT_MODEL, envvar="QA_CONTEXT_MODEL")
+@click.option(
+    "--context-model",
+    help="Model name or path for splitting contexts by token length",
+    default=DEFAULT_MODEL,
+    envvar="QA_CONTEXT_MODEL",
+)
 def split(
     input_path: str,
     output_path: str,
@@ -105,13 +129,27 @@ def split(
     save_data(dataset, output_path)
 
 
-@data_cli.command(short_help="Embed the text field of the dataset for semantic search, and save the result")
+@data_cli.command(
+    short_help="Embed the text field of the dataset for semantic search, and save the result"
+)
 @click.argument("input-path", required=True)
 @click.option("-o", "--output-path", required=True, help="Output path for the parsed dataset")
 @click.option("--input-type", help="Input file type. Defaults to file extension.")
 @click.option("--batch-size", help="Batch size for processing rows of the dataset", default=100)
-@click.option("devices", "-d", "--device", multiple=True, help="One or more devices to run embeddings on. Pass 'auto' to auto-detect multiple-gpus.", default=None)
-@click.option("--context-model", help="Model name or path for context embedding", default=DEFAULT_MODEL, envvar="QA_CONTEXT_MODEL")
+@click.option(
+    "devices",
+    "-d",
+    "--device",
+    multiple=True,
+    help="One or more devices to run embeddings on. Pass 'auto' to auto-detect multiple-gpus.",
+    default=None,
+)
+@click.option(
+    "--context-model",
+    help="Model name or path for context embedding",
+    default=DEFAULT_MODEL,
+    envvar="QA_CONTEXT_MODEL",
+)
 def embed(
     input_path: str,
     output_path: str,
@@ -129,14 +167,35 @@ def embed(
     save_data(dataset, output_path)
 
 
-@data_cli.command(short_help="Full processing pipeline for getting a document dataset ready to be indexed")
+@data_cli.command(
+    short_help="Full processing pipeline for getting a document dataset ready to be indexed"
+)
 @click.argument("input-path", required=True)
 @click.option("-o", "--output-path", required=True, help="Output path for the parsed dataset")
 @click.option("--input-type", help="Input file type. Defaults to file extension.")
 @click.option("--batch-size", help="Batch size for processing rows of the dataset", default=100)
-@click.option("devices", "-d", "--device", multiple=True, help="One or more devices to run embeddings on. Pass 'auto' to auto-detect multiple-gpus.", default=None)
-@click.option("--context-model", help="Model name or path for context embedding", default=DEFAULT_MODEL, envvar="QA_CONTEXT_MODEL")
-def pipeline(input_path: str, output_path: str, input_type: Optional[str], batch_size: int, devices: Optional[List[str]], context_model: str):
+@click.option(
+    "devices",
+    "-d",
+    "--device",
+    multiple=True,
+    help="One or more devices to run embeddings on. Pass 'auto' to auto-detect multiple-gpus.",
+    default=None,
+)
+@click.option(
+    "--context-model",
+    help="Model name or path for context embedding",
+    default=DEFAULT_MODEL,
+    envvar="QA_CONTEXT_MODEL",
+)
+def pipeline(
+    input_path: str,
+    output_path: str,
+    input_type: Optional[str],
+    batch_size: int,
+    devices: Optional[List[str]],
+    context_model: str,
+):
     dataset = load_data(input_path, input_type)
     embedding = QAEmbeddings(context_model)
     embedding_devices = embedding.multiprocess(*devices) if devices else [embedding]

--- a/llm/qa/cli/pubmed.py
+++ b/llm/qa/cli/pubmed.py
@@ -16,7 +16,9 @@ import shutil
 from tqdm.contrib.concurrent import process_map
 
 
-@click.group(name="pubmed", short_help="Commands for downloading PubMed and formatting it into a dataset")
+@click.group(
+    name="pubmed", short_help="Commands for downloading PubMed and formatting it into a dataset"
+)
 def pubmed_cli():
     pass
 
@@ -26,7 +28,7 @@ def pubmed_cli():
 def download(output_path: str):
     url = "https://ftp.ncbi.nlm.nih.gov/pubmed/baseline/"
     resp = requests.get(url)
-    links = BeautifulSoup(resp.content, parse_only=SoupStrainer('a'))
+    links = BeautifulSoup(resp.content, parse_only=SoupStrainer("a"))
     links = list(links)
 
     from tqdm import tqdm
@@ -63,7 +65,9 @@ def jsonl(input_path: str, output_path: str, tmp_path: str, nprocs: int = 1):
 @click.argument("output-path")
 @click.option("--nprocs", default=1)
 @click.option("--titles", "--title", multiple=True, required=False)
-def make_single_jsonl(input_path: str, output_path: str, nprocs: int = 1, titles: Optional[List[str]] = None):
+def make_single_jsonl(
+    input_path: str, output_path: str, nprocs: int = 1, titles: Optional[List[str]] = None
+):
     paths = [join(input_path, x) for x in os.listdir(input_path)]
     if not exists(output_path):
         os.makedirs(output_path)
@@ -121,7 +125,7 @@ def parse_node(node):
     publication_title = None
     _ = node.find(".//Abstract")
     if _ is not None:
-        text = etree.tostring(_, encoding="utf-8", method='text')
+        text = etree.tostring(_, encoding="utf-8", method="text")
         text = to_string(text)
     _ = node.find(".//ArticleTitle")
     if _ is not None:
@@ -151,11 +155,11 @@ def handle_one_xml(input_path: str, output_path: str, tmpdir: str):
             data = parse_node(node)
             all_data.append(data)
     try:
-        with tempfile.NamedTemporaryFile(mode='w+', dir=tmpdir, delete=False) as fout:
+        with tempfile.NamedTemporaryFile(mode="w+", dir=tmpdir, delete=False) as fout:
             for data in all_data:
                 if data["text"] and data["title"]:
                     fout.write(json.dumps(data))
-                    fout.write('\n')
+                    fout.write("\n")
             shutil.move(fout.name, output_path)
     except Exception as e:
         raise

--- a/llm/qa/crawler.py
+++ b/llm/qa/crawler.py
@@ -70,6 +70,7 @@ class DocSpider(Spider):
         )
         dataset = Dataset.from_dict({"source": [], "text": [], "title": []})
         scrape_finished: bool = False
+
         def _append_content(item):
             nonlocal dataset
             # Not sure what scrapy is doing, but there are some unhashable parts of the item
@@ -123,7 +124,9 @@ class DocSpider(Spider):
         for url in self.extract_links(link_base, soup, self.link_css):
             yield Request(url, self.parse, meta={"dont_redirect": self.dont_redirect})
 
-    def extract_links(self, base_url: str, soup: BeautifulSoup, css_selector: Optional[str] = None) -> Iterable[str]:
+    def extract_links(
+        self, base_url: str, soup: BeautifulSoup, css_selector: Optional[str] = None
+    ) -> Iterable[str]:
         if css_selector:
             for element in soup.select(css_selector):
                 return self.extract_links(base_url, element)

--- a/llm/qa/embedding.py
+++ b/llm/qa/embedding.py
@@ -27,6 +27,7 @@ class QAEmbeddings(Embeddings):
     Models that use separate weights to embed contexts and questions,
     (e.g. DPR models) may pass a separate question model/tokenizer.
     """
+
     context_model: PreTrainedModel
     context_tokenizer: PreTrainedTokenizerBase
     question_model: PreTrainedModel
@@ -97,6 +98,7 @@ class QAEmbeddings(Embeddings):
         if set_start_method:
             # Required to fork a process using CUDA
             import multiprocess
+
             multiprocess.set_start_method("spawn")
         return embeddings
 

--- a/llm/qa/parser.py
+++ b/llm/qa/parser.py
@@ -37,6 +37,7 @@ class DatasetParser:
     Pass multiple embedding devices to support multiprocessed embeddings.
     Each should be running on a different device (e.g. GPU1, GPU2,...)
     """
+
     def __init__(self, *embedding_devices: Embeddings) -> None:
         self.embedding_devices = embedding_devices
 
@@ -63,6 +64,7 @@ class DatasetParser:
             source_id_field: Use custom ID column instead of generating UUIDs
             include_meta: Filter columns that will be kept along with text and ID
         """
+
         def _parse_batch(
             batch: Dict[str, List],
             source_text_field: str,
@@ -123,6 +125,7 @@ class DatasetParser:
 
         Map ID -> DOC_ID, and assign a new ID to each split
         """
+
         def _split_batch(
             batch: Dict[str, List],
         ) -> Dict:
@@ -169,6 +172,7 @@ class DatasetParser:
         """
         Compute semantic embeddings for the text field and add to the dataset
         """
+
         def _embed_batch(batch: Dict[str, List], rank: Optional[int]) -> Dict:
             texts = batch[DataFields.TEXT]
             embeddings = self.embedding(rank).embed_documents(texts)
@@ -180,7 +184,11 @@ class DatasetParser:
         self._validate(dataset, exclude=[DataFields.EMBEDDING])
         logger.info("Embedding dataset")
         return dataset.map(
-            _embed_batch, batched=True, batch_size=batch_size, num_proc=len(self.embedding_devices), with_rank=True
+            _embed_batch,
+            batched=True,
+            batch_size=batch_size,
+            num_proc=len(self.embedding_devices),
+            with_rank=True,
         )
 
     def index(

--- a/llm/qa/prompts.py
+++ b/llm/qa/prompts.py
@@ -16,33 +16,35 @@ class ZeroShotQA(Prompt):
 
 @dataclass
 class FewShotQA(ZeroShotQA):
-    examples: List[Message] = field(default_factory=lambda: [
-        Message(
-            contexts=[
-                "No Waiver. Failure or delay in exercising any right or remedy under this Agreement shall not constitute a waiver of such (or any other)  right or remedy.11.7 Severability.",
-                "This Agreement is governed by English law and the parties submit to the exclusive jurisdiction of the English courts in relation to any dispute (contractual or non-contractual) concerning this Agreement save that either party may apply to any court for an injunction or other relief to protect its Intellectual Property Rights.",
-                "(b) if Google believes, in good faith, that the Distributor has violated or caused Google to violate any Anti-Bribery Laws (as  defined in Clause 8.5) or that such a violation is reasonably likely to occur,",
-            ],
-            input="Which state/country's law governs the interpretation of the contract?",
-            response="This Agreement is governed by English law.",
-        ),
-        Message(
-            contexts=[
-                "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans. Last year COVID-19 kept us apart. This year we are finally together again",
-                "More support for patients and families. To get there, I call on Congress to fund ARPA-H, the Advanced Research Projects Agency for Health. It's based on DARPA—the Defense Department project that led to the Internet, GPS, and so much more.  ARPA-H will have a singular purpose—to drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
-            ],
-            input="What did the president say about Michael Jackson?",
-            response="I don't know"
-        ),
-        Message(
-            contexts=[
-                "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans. Last year COVID-19 kept us apart. This year we are finally together again.",
-                "More support for patients and families. To get there, I call on Congress to fund ARPA-H, the Advanced Research Projects Agency for Health. It's based on DARPA—the Defense Department project that led to the Internet, GPS, and so much more.  ARPA-H will have a singular purpose—to drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
-            ],
-            input="What is the purpose of ARPA-H?",
-            response="The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more."
-        ),
-    ])
+    examples: List[Message] = field(
+        default_factory=lambda: [
+            Message(
+                contexts=[
+                    "No Waiver. Failure or delay in exercising any right or remedy under this Agreement shall not constitute a waiver of such (or any other)  right or remedy.11.7 Severability.",
+                    "This Agreement is governed by English law and the parties submit to the exclusive jurisdiction of the English courts in relation to any dispute (contractual or non-contractual) concerning this Agreement save that either party may apply to any court for an injunction or other relief to protect its Intellectual Property Rights.",
+                    "(b) if Google believes, in good faith, that the Distributor has violated or caused Google to violate any Anti-Bribery Laws (as  defined in Clause 8.5) or that such a violation is reasonably likely to occur,",
+                ],
+                input="Which state/country's law governs the interpretation of the contract?",
+                response="This Agreement is governed by English law.",
+            ),
+            Message(
+                contexts=[
+                    "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans. Last year COVID-19 kept us apart. This year we are finally together again",
+                    "More support for patients and families. To get there, I call on Congress to fund ARPA-H, the Advanced Research Projects Agency for Health. It's based on DARPA—the Defense Department project that led to the Internet, GPS, and so much more.  ARPA-H will have a singular purpose—to drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
+                ],
+                input="What did the president say about Michael Jackson?",
+                response="I don't know",
+            ),
+            Message(
+                contexts=[
+                    "Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans. Last year COVID-19 kept us apart. This year we are finally together again.",
+                    "More support for patients and families. To get there, I call on Congress to fund ARPA-H, the Advanced Research Projects Agency for Health. It's based on DARPA—the Defense Department project that led to the Internet, GPS, and so much more.  ARPA-H will have a singular purpose—to drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
+                ],
+                input="What is the purpose of ARPA-H?",
+                response="The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
+            ),
+        ]
+    )
 
 
 @dataclass
@@ -50,38 +52,42 @@ class StandaloneQuestion(Prompt):
     system_message: str = "Given the following conversation and a followup question, rephrase the followup question as a standalone question with any relevant context. The final answer should be a concise search query that will find results relevant to the followup question."
     input_template: str = "Followup Question: {text}"
     response_template: str = "Standalone Question: {text}"
-    context_prompt: Prompt = field(default_factory=lambda: Prompt(
-        input_template="Question: {text}",
-        response_template="Answer: {text}",
-    ))
-    examples: List[Message] = field(default_factory=lambda: [
-        Message(
-            contexts=[
-                "What is the purpose of ARPA-H?",
-                "The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
-            ],
-            input="When was it created?",
-            response="When was the Advanced Research Projects Agency for Health created?"
-        ),
-        Message(
-            contexts=[
-                "What is the purpose of ARPA-H?",
-                "The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
-                "When was it created?",
-                "The Advanced Research Projects Agency for Health was created on March 15, 2022",
-            ],
-            input="What are some of the other breakthroughs?",
-            response="In addition to cancer, Alzheimer's, and diabetes, what are some other breakthroughs driven by the Advanced Research Projects Agency for Health?",
-        ),
-        Message(
-            contexts=[
-                "Which state/country's law governs the interpretation of the contract?",
-                "This Agreement is governed by English law.",
-            ],
-            input="Who are the primary parties bound by the contract?",
-            response="Who are the primary parties bound by the contract?",
-        ),
-    ])
+    context_prompt: Prompt = field(
+        default_factory=lambda: Prompt(
+            input_template="Question: {text}",
+            response_template="Answer: {text}",
+        )
+    )
+    examples: List[Message] = field(
+        default_factory=lambda: [
+            Message(
+                contexts=[
+                    "What is the purpose of ARPA-H?",
+                    "The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
+                ],
+                input="When was it created?",
+                response="When was the Advanced Research Projects Agency for Health created?",
+            ),
+            Message(
+                contexts=[
+                    "What is the purpose of ARPA-H?",
+                    "The Advanced Research Projects Agency for Health will drive breakthroughs in cancer, Alzheimer's, diabetes, and more.",
+                    "When was it created?",
+                    "The Advanced Research Projects Agency for Health was created on March 15, 2022",
+                ],
+                input="What are some of the other breakthroughs?",
+                response="In addition to cancer, Alzheimer's, and diabetes, what are some other breakthroughs driven by the Advanced Research Projects Agency for Health?",
+            ),
+            Message(
+                contexts=[
+                    "Which state/country's law governs the interpretation of the contract?",
+                    "This Agreement is governed by English law.",
+                ],
+                input="Who are the primary parties bound by the contract?",
+                response="Who are the primary parties bound by the contract?",
+            ),
+        ]
+    )
 
     @property
     def stop_strings(self) -> List[str]:

--- a/llm/qa/session.py
+++ b/llm/qa/session.py
@@ -18,6 +18,7 @@ class QASession:
     Contexts relevant to questions are retrieved from the given vector store and appended
     to the system prompt that is fed into inference.
     """
+
     def __init__(
         self,
         engine: InferenceEngine,
@@ -59,7 +60,9 @@ class QASession:
             qa_prompt = qa_prompt.from_model_config(model_config)
         if isinstance(rephrase_prompt, type):
             rephrase_prompt = rephrase_prompt.from_model_config(model_config)
-        return cls(engine, vector_store, qa_prompt=qa_prompt, rephrase_prompt=rephrase_prompt, **kwargs)
+        return cls(
+            engine, vector_store, qa_prompt=qa_prompt, rephrase_prompt=rephrase_prompt, **kwargs
+        )
 
     def stream_answer(self, question: str, update_context: bool = False, **kwargs) -> Iterable[str]:
         """
@@ -162,7 +165,12 @@ class QASession:
             return self.conversation.messages[-1]
         return None
 
-    def get_history(self, user_label: str = "Question: ", assistant_label: str = "Answer: ", separator: str = "\n") -> str:
+    def get_history(
+        self,
+        user_label: str = "Question: ",
+        assistant_label: str = "Answer: ",
+        separator: str = "\n",
+    ) -> str:
         """
         Get conversation history formatted as a string
         """

--- a/llm/qa/streamlit/app.py
+++ b/llm/qa/streamlit/app.py
@@ -18,7 +18,9 @@ QA_CHAT_MODEL = os.getenv("QA_CHAT_MODEL", VicunaConfig.model_id)
 
 
 @st.cache_resource
-def get_vector_store(dataset_path: Optional[str] = None, index_path: Optional[str] = None) -> DatasetVectorStore:
+def get_vector_store(
+    dataset_path: Optional[str] = None, index_path: Optional[str] = None
+) -> DatasetVectorStore:
     if not dataset_path:
         dataset_path = QA_DATASET_PATH
     if not index_path:
@@ -30,7 +32,13 @@ def get_vector_store(dataset_path: Optional[str] = None, index_path: Optional[st
     return DatasetVectorStore(dataset, embedding, index_path=index_path)
 
 
-def get_qa_session(model_config: ModelConfig, engine: InferenceEngine, vector_store: VectorStore, debug: bool = True, **kwargs) -> QASession:
+def get_qa_session(
+    model_config: ModelConfig,
+    engine: InferenceEngine,
+    vector_store: VectorStore,
+    debug: bool = True,
+    **kwargs
+) -> QASession:
     # Conversation/contexts for each session
     if "qa_session" not in st.session_state:
         qa_session = QASession.from_model_config(
@@ -79,8 +87,12 @@ def render_app(
                 value=True,
             )
             num_contexts = st.number_input(label="Num Contexts", min_value=0, value=num_contexts)
-            max_new_tokens = st.number_input(label="Max New Tokens", min_value=1, value=max_new_tokens)
-            temperature = st.slider(label="Temperature", min_value=0.0, max_value=1.0, step=0.05, value=temperature)
+            max_new_tokens = st.number_input(
+                label="Max New Tokens", min_value=1, value=max_new_tokens
+            )
+            temperature = st.slider(
+                label="Temperature", min_value=0.0, max_value=1.0, step=0.05, value=temperature
+            )
             top_p = st.slider(label="Top P", min_value=0.0, max_value=1.0, step=0.05, value=top_p)
             st.form_submit_button(label="Apply")
 
@@ -98,7 +110,9 @@ def render_app(
         # Rephrase and search for contexts
         with st.spinner("Searching..."):
             if rephrase_question:
-                search_query = qa_session.rephrase_question(user_input, temperature=temperature, top_p=top_p)
+                search_query = qa_session.rephrase_question(
+                    user_input, temperature=temperature, top_p=top_p
+                )
             else:
                 search_query = user_input
             st.session_state["search_query"] = search_query
@@ -112,13 +126,20 @@ def render_app(
             st.caption(st.session_state["search_query"])
         with st.form(key="checklists"):
             for i, doc in enumerate(qa_session.results):
-                include = st.checkbox("include in chat context", key=i, value=True, disabled=search_new_context)
+                include = st.checkbox(
+                    "include in chat context", key=i, value=True, disabled=search_new_context
+                )
                 included.append(include)
                 st.write(doc.page_content)
-                st.json({k: v for k, v in doc.metadata.items() if k != DataFields.EMBEDDING}, expanded=False)
+                st.json(
+                    {k: v for k, v in doc.metadata.items() if k != DataFields.EMBEDDING},
+                    expanded=False,
+                )
                 st.divider()
 
-            checklist_submitted = st.form_submit_button(label="Filter", disabled=(not qa_session.results))
+            checklist_submitted = st.form_submit_button(
+                label="Filter", disabled=(not qa_session.results)
+            )
             if checklist_submitted:
                 filter_contexts(qa_session, included)
 

--- a/llm/qa/streamlit/transformer_backend.py
+++ b/llm/qa/streamlit/transformer_backend.py
@@ -10,7 +10,9 @@ from llm.qa.streamlit.app import QA_CHAT_MODEL, get_qa_session, get_vector_store
 
 
 @st.cache_resource
-def get_inference_engine(model_config: ModelConfig, num_workers: Optional[int] = None) -> InferenceEngine:
+def get_inference_engine(
+    model_config: ModelConfig, num_workers: Optional[int] = None
+) -> InferenceEngine:
     # MultiprocessEngine ensures sessions gets dedicated access to a model
     # while their request is being processed. By default, one inference engine will
     # be loaded to each available GPU device.
@@ -30,7 +32,9 @@ if __name__ == "__main__":
 
     parser = ArgumentParser()
     parser.add_argument("-m", "--model-id", help="Chat model ID", default=QA_CHAT_MODEL)
-    parser.add_argument("-n", "--num-workers", help="Number of chat models to run. Defaults to num GPUs.")
+    parser.add_argument(
+        "-n", "--num-workers", help="Number of chat models to run. Defaults to num GPUs."
+    )
     args = parser.parse_args()
 
     model_config = ModelConfig.from_registry(args.model_id)

--- a/llm/qa/streamlit/vllm_client_backend.py
+++ b/llm/qa/streamlit/vllm_client_backend.py
@@ -39,7 +39,10 @@ if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("url", help="Base URL for vLLM API")
     parser.add_argument(
-        "-m", "--model-id", help="Chat model ID for determining prompt format", default=QA_CHAT_MODEL
+        "-m",
+        "--model-id",
+        help="Chat model ID for determining prompt format",
+        default=QA_CHAT_MODEL,
     )
     args = parser.parse_args()
 

--- a/llm/qa/vector_store.py
+++ b/llm/qa/vector_store.py
@@ -17,6 +17,7 @@ class DatasetVectorStore(VectorStore):
     Implements langchain's VectorStore interface on a huggingface dataset
     with FAISS for semantic search.
     """
+
     def __init__(
         self,
         dataset: Dataset,
@@ -56,9 +57,7 @@ class DatasetVectorStore(VectorStore):
         for row in dataset:
             self.dataset.add_item(row)
 
-    def similarity_search(
-        self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+    def similarity_search(self, query: str, k: int = 4, **kwargs: Any) -> List[Document]:
         query_embedding = self.embedding.embed_query(query)
         np_embedding = np.asarray(query_embedding, dtype=np.float32)
         results = self.dataset.search(self.index_name, np_embedding, k, **kwargs)

--- a/llm/utils/data.py
+++ b/llm/utils/data.py
@@ -21,9 +21,7 @@ def load_data(input_path: str, input_type: Optional[str] = None) -> Dataset:
     if input_type == "jsonl":
         input_type = "json"
 
-    return load_dataset(
-        input_type, data_files={split: input_path}, split=split
-    )
+    return load_dataset(input_type, data_files={split: input_path}, split=split)
 
 
 def merge_dict(a: Dict, b: Dict) -> Dict:


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Removing `last` kwarg since it is always tied to a null response anway. Add `with_response_prefix` kwarg on render_instruction to enable easily generating the full instruction prompt from a message during training. Useful for supervised training where the labels of the instruction are masked.

Also ran `black -l 100` to get consistent formatting  across the repo.