### PR TITLE
Logging config

### DIFF
--- a/llm/model_configs.py
+++ b/llm/model_configs.py
@@ -24,7 +24,9 @@ from llm.prompt import (
     TogetherLlama2Format,
     VicunaFormat,
 )
+from llm.utils.logs import get_logger
 
+logger = get_logger()
 _registry: Dict[str, Type[ModelConfig]] = {}
 
 
@@ -90,7 +92,7 @@ class ModelConfig:
             if peft_base_id and peft_base_id in _registry:
                 cls = _registry[peft_base_id]
             else:
-                logging.warn(
+                logger.warn(
                     f'ModelConfig "{model_id}" not found in registry. Using generic configuration.'
                 )
 

--- a/llm/model_configs.py
+++ b/llm/model_configs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple, Type, Union
@@ -85,18 +84,21 @@ class ModelConfig:
         Load model config from the registry
         """
         model_id = trim_model_path(model_id)
+        config_cls = cls
         if model_id in _registry:
-            cls = _registry[model_id]
+            config_cls = _registry[model_id]
         else:
             peft_base_id = fetch_peft_base(model_id)
             if peft_base_id and peft_base_id in _registry:
-                cls = _registry[peft_base_id]
+                config_cls = _registry[peft_base_id]
             else:
                 logger.warn(
                     f'ModelConfig "{model_id}" not found in registry. Using generic configuration.'
                 )
+        if not (cls == config_cls or issubclass(config_cls, cls)):
+            logger.warn(f'Registry entry for "{model_id}" {config_cls} is not a subclass of {cls}')
 
-        return cls(model_id=model_id, **kwargs)
+        return config_cls(model_id=model_id, **kwargs)
 
     def load(
         self,

--- a/llm/settings.py
+++ b/llm/settings.py
@@ -1,6 +1,7 @@
 import os
 
 
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 LOCAL_MODELS_DIR = os.getenv("LOCAL_MODELS_DIR", "models/")
 SATURNFS_MODELS_DIR = os.getenv("SATURNFS_MODELS_DIR", None)
 

--- a/llm/utils/logs.py
+++ b/llm/utils/logs.py
@@ -1,0 +1,17 @@
+import logging
+from typing import Optional
+
+from llm import settings
+
+def get_logger(name: str = "saturn-llm") -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(settings.LOG_LEVEL)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(settings.LOG_LEVEL)
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    return logger


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Basic logging configuration, and warn if someone loads a ModelConfig from the registry with a different subclass than what is registered e.g. `Llama2Config.from_registry("lmsys/vicuna-7b-v1.5")` 