### PR TITLE
Standardize the kwargs passthrough for from_model_config methods

### DIFF
--- a/examples/streamlit_ui/components.py
+++ b/examples/streamlit_ui/components.py
@@ -114,7 +114,7 @@ def get_transformers_engine(
     return MultiprocessEngine.from_model_config(
         model_config,
         num_workers=num_workers,
-        model_kwargs={
+        load_kwargs={
             "torch_dtype": torch.float16,
             "quantization_config": bnb_quantization(),
         },

--- a/llm/inference/transformer.py
+++ b/llm/inference/transformer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import gc
 
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 from transformers import (
@@ -35,9 +35,10 @@ class TransformersEngine(InferenceEngine):
         self.max_length = max_length
 
     @classmethod
-    def from_model_config(cls, model_config: ModelConfig, **kwargs) -> TransformersEngine:
-        model, tokenizer = model_config.load(**kwargs)
-        return cls(model, tokenizer, max_length=model_config.max_length)
+    def from_model_config(cls, model_config: ModelConfig, load_kwargs: Optional[Dict[str, Any]] = None, **kwargs) -> TransformersEngine:
+        model, tokenizer = model_config.load(**(load_kwargs or {}))
+        kwargs.setdefault("max_length", model_config.max_length)
+        return cls(model, tokenizer, **kwargs)
 
     @torch.inference_mode()
     def generate_stream(

--- a/llm/model_configs.py
+++ b/llm/model_configs.py
@@ -106,14 +106,13 @@ class ModelConfig:
     def load(
         self,
         device_map: Optional[Union[str, Dict]] = None,
-        model_kwargs: Optional[Dict[str, Any]] = None,
         tokenizer_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Tuple[PreTrainedModel, PreTrainedTokenizerBase]:
-        model_kwargs = model_kwargs or {}
         tokenizer_kwargs = tokenizer_kwargs or {}
         if device_map is not None:
-            model_kwargs["device_map"] = device_map
-        model = self.load_model(**model_kwargs)
+            kwargs["device_map"] = device_map
+        model = self.load_model(**kwargs)
         tokenizer = self.load_tokenizer(**tokenizer_kwargs)
         return model, tokenizer
 

--- a/llm/qa/session.py
+++ b/llm/qa/session.py
@@ -50,7 +50,7 @@ class QASession:
         if engine is None:
             engine = TransformersEngine.from_model_config(
                 model_config,
-                model_kwargs={
+                load_kwargs={
                     "device_map": "auto",
                     "torch_dtype": torch.float16,
                     "quantization_config": bnb_quantization(),


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Pass model kwargs directly into `model_config.load(....)` as that is the most frequent usage. Standardize the way kwargs are passed through to load on `from_model_config` classmethods that load the model.