### PR TITLE
Bhperry/inference api

### DIFF
--- a/llm/inference/api/main.py
+++ b/llm/inference/api/main.py
@@ -1,0 +1,113 @@
+import argparse
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+import json
+
+from fastapi import APIRouter, FastAPI
+from fastapi.responses import StreamingResponse
+import uvicorn
+
+from llm.inference.multiproc import MultiprocessEngine
+from llm.inference.types import InferenceRequest
+from llm.model_configs import ModelConfig, VicunaConfig, bnb_quantization
+
+
+engine: MultiprocessEngine
+router = APIRouter()
+
+
+@dataclass
+class InferenceAPIRequest(InferenceRequest):
+    streaming: bool = False
+
+
+@router.post("/api/inference")
+def inference_endpoint(data: InferenceAPIRequest):
+    stream = engine.add_request(data)
+
+    # Stream partial responses as Server Sent Events
+    if data.streaming:
+        def stream_resp():
+            while True:
+                response = stream.get()
+                yield f"data: {json.dumps(response.to_dict())}\n\n"
+
+                if response.stopped:
+                    break
+            yield "data: [DONE]\n\n"
+        return StreamingResponse(stream_resp(), media_type="text/event-stream")
+
+    # Non-streaming response
+    while True:
+        response = stream.get()
+        if response.stopped:
+            return response.to_dict()
+
+
+@asynccontextmanager
+async def engine_lifecycle(app: FastAPI):
+    yield
+    engine.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default=None)
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "-m", "--model-id", help="Model ID", default=VicunaConfig.model_id
+    )
+    parser.add_argument(
+        "-n",
+        "--num-workers",
+        help="Number of chat models to run. Defaults to num GPUs.",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch-size",
+        help="Maximum batch size for a single model",
+        default=8,
+    )
+    parser.add_argument(
+        "-d",
+        "--delay",
+        help="Maximum delay in seconfds after first request for batching",
+        default=0.5,
+    )
+    parser.add_argument(
+        "-p",
+        "--pending",
+        help="Maximum number of pending requests (does not include active)",
+        default=-1.
+    )
+    parser.add_argument(
+        "-q",
+        "--quantization",
+        default="4bit",
+        choices=("4bit", "8bit", "none"),
+        help="Quantize the model during load with bitsandbytes",
+    )
+    args = parser.parse_args()
+
+    quantization = args.quantization.lower()
+    config = ModelConfig.from_registry(args.model_id)
+    engine = MultiprocessEngine.from_model_config(
+        config,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        max_delay=args.delay,
+        max_pending=args.pending,
+        load_kwargs={
+            "quantization_config": (
+                bnb_quantization(quantization) if quantization != "none" else None
+            )
+        }
+    )
+
+    app = FastAPI(lifespan=engine_lifecycle, engine=engine)
+    app.include_router(router)
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+    )

--- a/llm/inference/base.py
+++ b/llm/inference/base.py
@@ -11,7 +11,7 @@ class InferenceEngine(ABC):
 
     @abstractmethod
     def generate_stream(
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -25,7 +25,7 @@ class InferenceEngine(ABC):
 
     def generate(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -34,7 +34,7 @@ class InferenceEngine(ABC):
     ) -> str:
         answer = ""
         for _answer in self.generate_stream(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,

--- a/llm/inference/multiproc.py
+++ b/llm/inference/multiproc.py
@@ -178,7 +178,7 @@ class MultiprocessEngine(InferenceEngine):
 
     def generate_stream(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -187,7 +187,7 @@ class MultiprocessEngine(InferenceEngine):
         **kwargs,
     ) -> Iterable[str]:
         request = InferenceRequest(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,

--- a/llm/inference/transformer.py
+++ b/llm/inference/transformer.py
@@ -112,7 +112,7 @@ class TransformersEngine(InferenceEngine):
 
     def generate_stream(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -124,7 +124,7 @@ class TransformersEngine(InferenceEngine):
         Single-prompt inference streaming wrapper.
         """
         request = InferenceRequest(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,
@@ -137,7 +137,7 @@ class TransformersEngine(InferenceEngine):
 
     def generate(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -148,7 +148,7 @@ class TransformersEngine(InferenceEngine):
         Single-prompt inference wrapper.
         """
         request = InferenceRequest(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,
@@ -357,7 +357,7 @@ class TransformersEngine(InferenceEngine):
         if (token_interval > 0 and state.resp.tokens_generated % token_interval == 0) or state.resp.stopped:
             # Decode tokens, and check if an update needs to be yielded
             if state.req.echo_prompt:
-                rfind_start = len(state.prompt)
+                rfind_start = len(state.input_text)
             else:
                 rfind_start = 0
 
@@ -392,13 +392,13 @@ class TransformersEngine(InferenceEngine):
             if req.stop_token_ids is None:
                 if self.tokenizer.eos_token_id is not None:
                     req.stop_token_ids = [self.tokenizer.eos_token_id]
-            if isinstance(req.prompt, str):
-                to_tokenize.append((i, req.prompt))
-                prompts[i] = req.prompt
+            if isinstance(req.input, str):
+                to_tokenize.append((i, req.input))
+                prompts[i] = req.input
             else:
-                input_ids[i] = req.prompt
+                input_ids[i] = req.input
                 prompts[i] = self.tokenizer.decode(
-                    req.prompt,
+                    req.input,
                     skip_special_tokens=True,
                     spaces_between_special_tokens=False,
                     clean_up_tokenization_spaces=True,

--- a/llm/inference/types.py
+++ b/llm/inference/types.py
@@ -12,7 +12,7 @@ class InferenceRequest(DataclassBase):
     """
     Input data for inference
     """
-    prompt: Union[str, List[int]]
+    input: Union[str, List[int]]
 
     uid: str = field(default_factory=lambda: uuid4().hex)
     max_new_tokens: int = 256
@@ -47,7 +47,7 @@ class InferenceState:
     Stores information about an in-progress inference request/response
     """
     req: InferenceRequest
-    prompt: str
+    input_text: str
     input_ids: List[int]
     output_updated: bool = False
 

--- a/llm/inference/vllm_client.py
+++ b/llm/inference/vllm_client.py
@@ -18,7 +18,7 @@ class VLLMClient(InferenceEngine):
 
     def generate_stream(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -26,7 +26,7 @@ class VLLMClient(InferenceEngine):
         **kwargs,
     ) -> Iterable[str]:
         return self._request(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,
@@ -37,7 +37,7 @@ class VLLMClient(InferenceEngine):
 
     def generate(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int = 256,
         echo_prompt: bool = False,
         stop_token_ids: Optional[List[int]] = None,
@@ -46,7 +46,7 @@ class VLLMClient(InferenceEngine):
     ) -> str:
         text = ""
         for t in self._request(
-            prompt,
+            input,
             max_new_tokens=max_new_tokens,
             echo_prompt=echo_prompt,
             stop_token_ids=stop_token_ids,
@@ -59,7 +59,7 @@ class VLLMClient(InferenceEngine):
 
     def _request(
         self,
-        prompt: str,
+        input: str,
         max_new_tokens: int,
         echo_prompt: bool,
         stop_token_ids: Optional[List[int]] = None,
@@ -70,7 +70,7 @@ class VLLMClient(InferenceEngine):
         if not isinstance(stop_strings, list):
             stop_strings = [stop_strings]
         data = {
-            "prompt": prompt,
+            "prompt": input,
             "stream": stream,
             "max_tokens": max_new_tokens,
             "stop_strings": stop_strings,
@@ -84,7 +84,7 @@ class VLLMClient(InferenceEngine):
             for line in response.iter_lines(delimiter=b"\0"):
                 if line:
                     data = json.loads(line)
-                    answer = self._trim_answer(prompt, data["text"][0], echo_prompt=echo_prompt)
+                    answer = self._trim_answer(input, data["text"][0], echo_prompt=echo_prompt)
 
                     _, partial_stop = check_stop_str(answer, stop_strings)
                     if not partial_stop:
@@ -92,10 +92,10 @@ class VLLMClient(InferenceEngine):
                         yield answer
         else:
             data = response.json()
-            yield self._trim_answer(prompt, data["text"][0], echo_prompt=echo_prompt)
+            yield self._trim_answer(input, data["text"][0], echo_prompt=echo_prompt)
 
-    def _trim_answer(self, prompt: str, answer: str, echo_prompt: bool = False) -> str:
+    def _trim_answer(self, input: str, answer: str, echo_prompt: bool = False) -> str:
         if not echo_prompt:
-            if answer.startswith(prompt):
-                return answer[len(prompt) :]
+            if answer.startswith(input):
+                return answer[len(input) :]
         return answer


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Adding a simple fastapi wrapper on top of the MultiprocessEngine so that it can be run as a shared inference server.

Renaming the "prompt" input variable to "input" to avoid a naming collision with `llm.prompt.Prompt` should we decide to add a `/api/prompt` style endpoint for formatted/chat based inference.